### PR TITLE
NetworkObject Parenting

### DIFF
--- a/text/0000-networkobject-parenting.md
+++ b/text/0000-networkobject-parenting.md
@@ -211,17 +211,12 @@ Both UNet and Unreal does not offer a similar solution out-of-the-box and mostly
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
-- What parts of the design do you expect to resolve through the RFC process before this gets merged?
-- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
-- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
+- Why can't we queue up all the changes to a buffer in non-networked gameplay and simply sync all of them on connect/join?
+    - Technical MLAPI limitations, see details above in guide & reference level explanation sections.
+- Why `NetworkObject` parenting can't be client-driven?
+    - Similar to "Ownership" model we have, we trust server to be the source of truth and we simply rely on server-side logic for both ownership and here for parenting too.
 
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
-Think about what the natural extension and evolution of your proposal would be and how it would affect the Unity Multiplayer as a whole in a holistic way. Try to use this section as a tool to more fully consider all possible interactions with the Unity Multiplayer in your proposal. Also consider how the this all fits into the roadmap for the project and the team.
-
-This is also a good place to "dump ideas", if they are out of scope for the RFC you are writing but otherwise related.
-
-If you have tried and cannot think of any future possibilities, you may simply state that you cannot think of anything.
-
-Note that having something written down in the future-possibilities section is not a reason to accept the current or a future RFC; such notes should be in the section on motivation or rationale in this or subsequent RFCs. The section merely provides additional information.
+Potentially, we'll rework low-level core parts of MLAPI which would involve `NetworkObject`, `NetworkBehaviour` etc. and that'd also throw away all scene transform hierarchy related logic out and bump this user-need/feature to a higher-level construct like `NetworkTransform` in the future.

--- a/text/0000-networkobject-parenting.md
+++ b/text/0000-networkobject-parenting.md
@@ -1,7 +1,7 @@
 - Feature Name: `networkobject-parenting`
 - Start Date: 2021-05-26
-- RFC PR: [Unity-Technologies/com.unity.multiplayer.rfcs#0000](https://github.com/Unity-Technologies/com.unity.multiplayer.rfcs/pull/0000)
-- Issue: [Unity-Technologies/com.unity.multiplayer#0000](https://github.com/Unity-Technologies/com.unity.multiplayer/issues/0000)
+- RFC PR: [RFC#17](https://github.com/Unity-Technologies/com.unity.multiplayer.rfcs/pull/17)
+- Issue: [MLAPI#876](https://github.com/Unity-Technologies/com.unity.multiplayer.mlapi/issues/876)
 
 # Summary
 [summary]: #summary

--- a/text/0000-networkobject-parenting.md
+++ b/text/0000-networkobject-parenting.md
@@ -1,4 +1,4 @@
-- Feature Name: `object-parenting`
+- Feature Name: `networkobject-parenting`
 - Start Date: 2021-05-26
 - RFC PR: [Unity-Technologies/com.unity.multiplayer.rfcs#0000](https://github.com/Unity-Technologies/com.unity.multiplayer.rfcs/pull/0000)
 - Issue: [Unity-Technologies/com.unity.multiplayer#0000](https://github.com/Unity-Technologies/com.unity.multiplayer/issues/0000)
@@ -196,7 +196,7 @@ Having said that, we could expect this limitation to change and potentially no l
 
 ## Implementing A High-Level Concept In A Low-Level Context
 
-todo
+Both scene transform hierarchy and transform reparenting are higher-level and even arguably non-network concepts but they happened to appear in MLAPI's low-level design primitives. Network framework does not necessarily need to know about the scene hierachy, transforms and other systems in order to synchronize state of network entities (`NetworkObject`s) over the network. However, existing MLAPI architecture forms an hierarchy based on the scene transform hierarchy but it does not fully mirror it. We also have other bespoke `NetworkBehaviour` derived types such as `NetworkTransform`, `NetworkAnimator`, `NetworkRigidbody` etc. which are not considered as core parts of the MLAPI framework but rather supplied utilities/modules. This (re)parenting feature would be implemented at much higher-level as `NetworkTransform`/`NetworkRigidbody` if we were to isolate MLAPI core primitives from higher-level systems and concepts. This might change later in the roadmap or in future releases but FWIW, we still believe delivering `NetworkObject` reparenting out-of-the-box serves some customers and saves their time to better spend on the game they are crafting.
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives

--- a/text/0000-networkobject-parenting.md
+++ b/text/0000-networkobject-parenting.md
@@ -22,6 +22,10 @@ With this RFC implemented, we expect developers to reparent their `NetworkObject
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
+## Opt-out
+
+Before we dig deeper into this feature proposal, it needs to be said that this feature is going to be behind a bool flag that can be toggled on the `NetworkObject` inspector UI, which will be enabled by default but experienced developer can opt-out from it and wouldn't be running any of this logic if they were to implement a solution on their own.
+
 ## Rules
 
 Let's list a few basic `NetworkObject` reparenting rules below.

--- a/text/0000-networkobject-parenting.md
+++ b/text/0000-networkobject-parenting.md
@@ -201,9 +201,7 @@ Both scene transform hierarchy and transform reparenting are higher-level and ev
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
-- Why is this design the best in the space of possible designs?
-- What other designs have been considered and what is the rationale for not choosing them?
-- What is the impact of not doing this?
+- Given the limited time and scope, we think we cannot re-architect MLAPI fundamentals to support an approach where `NetworkObject` and `NetworkBehaviour` components are simply unaware of scene and transform hierarchy but they are plus parenting to be provided by a higher-level construct outside MLAPI core such as `NetworkTransform`. We wanted to move forward with what we already have.
 
 # Prior art
 [prior-art]: #prior-art

--- a/text/0000-networkobject-parenting.md
+++ b/text/0000-networkobject-parenting.md
@@ -208,16 +208,7 @@ Both scene transform hierarchy and transform reparenting are higher-level and ev
 # Prior art
 [prior-art]: #prior-art
 
-Discuss prior art, both the good and the bad, in relation to this proposal. A few examples of what this can include are:
-
-- For framework, tools, and library proposals: Does this feature exist in other networking stacks and what experience have their community had?
-- For community proposals: Is this done by some other community and what were their experiences with it?
-- For other teams: What lessons can we learn from what other communities have done here?
-- Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.
-
-This section is intended to encourage you as an author to think about the lessons from other projects, provide readers of your RFC with a fuller picture. If there is no prior art, that is fine - your ideas are interesting to us whether they are brand new or if it is an adaptation from other projects.
-
-Note that while precedent set by other projects is some motivation, it does not on its own motivate an RFC. Please also take into consideration that Unity Multiplayer sometimes intentionally diverges from common multiplayer networking features.
+Both UNet and Unreal does not offer a similar solution out-of-the-box and mostly leave it up to developers to roll their own. This option gives enough freedom to developers so that they could address their specific needs in their project in the given context. We might favor this approach but ultimately, product team wanted to offer something that works out-of-the-box, mostly targeting beginners and non-experts.
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions

--- a/text/0000-networkobject-parenting.md
+++ b/text/0000-networkobject-parenting.md
@@ -24,7 +24,7 @@ With this RFC implemented, we expect developers to reparent their `NetworkObject
 
 ## Opt-out
 
-Before we dig deeper into this feature proposal, it needs to be said that this feature is going to be behind a bool flag that can be toggled on the `NetworkObject` inspector UI, which will be enabled by default but experienced developer can opt-out from it and wouldn't be running any of this logic if they were to implement a solution on their own.
+Before we dig deeper into this feature proposal, it needs to be said that this feature is going to be behind a bool flag that can be toggled on the `NetworkObject` inspector UI, which will be enabled by default but experienced developers can opt-out from it and wouldn't be running any of this logic therefore they could to implement a solution on their own as well.
 
 ## Rules
 

--- a/text/0000-object-parenting.md
+++ b/text/0000-object-parenting.md
@@ -184,7 +184,19 @@ Transform parent synchronization will rely on initial formation of transforms in
 # Drawbacks
 [drawbacks]: #drawbacks
 
-Why should we _not_ do this?
+## Limiting Non-Networked NetworkObject Transform Parenting
+
+Rules outlined above are applied and enforced even while not networking (not hosting or connected). More specifically, if you were to try reparenting a `NetworkObject` under a non-`NetworkObject`, that'd be invalid and reverted even though you are not hosting or connected to a server.
+
+This is due to several limitations caused by current MLAPI design and resolving these issues are not in the scope of this proposed feature work.
+
+If framework were to allow any arbitrary `NetworkObject` parenting which might also include invalid moves, player would be desynced upon arrival/join/connect to the server. We might try to keep local changes in a buffer/cache but we still cannot guarantee those moves would be synced without issues on connect — so, we play safe instead of half-working approach here and still apply rules and prevent `NetworkObject` parenting to desync while not networking.
+
+Having said that, we could expect this limitation to change and potentially no longer exist if we were to address fundamental `NetworkObject` & `NetworkBehaviour` architecture in MLAPI.
+
+## Implementing A High-Level Concept In A Low-Level Context
+
+todo
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives

--- a/text/0000-object-parenting.md
+++ b/text/0000-object-parenting.md
@@ -74,7 +74,7 @@ So, let's try a few moves!
 
 ### Root/Axe → RightHand/Axe
 
-In networked gameplay, this is a valid move because `Axe (NetworkObject)` is being moved under `RightHand (NetworkObject)`. We know about their `NetworkObjectId`s and it will be replicated across the network to clients by the server.
+This is a **valid** move because `Axe (NetworkObject)` is being moved under `RightHand (NetworkObject)`. We know about their `NetworkObjectId`s and it will be replicated across the network to clients by the server.
 
 Now, our hierarchy is looking like this:
 
@@ -91,23 +91,42 @@ Player (NetworkObject)
   │  └─ RightArm
   │     └─ RightHand (NetworkObject)
   │        └─ Axe (NetworkObject) [to] <──┐
-  └─ Legs                                 │ OK
+  └─ Legs                                 ├ OK
                                 [from] ───┘
 ```
 
 ### RightHand/Axe → Body/Axe
 
+This is an **invalid** move because `Axe (NetworkObject)` is being moved under `Body` which is _not_ a `NetworkObject`. It does _not_ have a `NetworkObjectId` and it can _not_ be replicated and synced on clients.
+
+So, we tried to do this but it did _not_ succeed:
+
+```
+Sun
+Tree
+Camera
+Player (NetworkObject)
+  ├─ Head
+  ├─ Body
+  │                               [to] <──┐
+  ├─ Arms                                 │
+  │  ├─ LeftArm                           │
+  │  │  └─ LeftHand (NetworkObject)       ├ INVALID
+  │  └─ RightArm                          │
+  │     └─ RightHand (NetworkObject)      │
+  │        └─ Axe (NetworkObject) [from] ─┘
+  └─ Legs
+```
+
+We'd get an error message in the logs similar to this:
+
+```
+Invalid parenting, NetworkObject moved under a non-NetworkObject parent
+```
+
+### RightHand/Axe → Scene Root
+
 todo
-
-Explain the proposal as if it was already included in the Unity Multiplayer and you were teaching it to another Unity developer. That generally means:
-
-- Introducing new named concepts.
-- Explaining the feature largely in terms of examples.
-- Explaining how Unity developers should _think_ about the feature, and how it should impact the way they develop multiplayer projects in Unity. It should explain the impact as concretely as possible.
-- If applicable, provide sample error messages, deprecation warnings, or migration guidance.
-- If applicable, describe the differences between teaching this to existing Unity developers and new Unity developers.
-
-For implementation-oriented RFCs (e.g. for framework internals), this section should focus on how Unity Multiplayer contributors should think about the change, and give examples of its concrete impact. For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation

--- a/text/0000-object-parenting.md
+++ b/text/0000-object-parenting.md
@@ -1,0 +1,164 @@
+- Feature Name: `object-parenting`
+- Start Date: 2021-05-26
+- RFC PR: [Unity-Technologies/com.unity.multiplayer.rfcs#0000](https://github.com/Unity-Technologies/com.unity.multiplayer.rfcs/pull/0000)
+- Issue: [Unity-Technologies/com.unity.multiplayer#0000](https://github.com/Unity-Technologies/com.unity.multiplayer/issues/0000)
+
+# Summary
+[summary]: #summary
+
+This RFC proposes a way to reparent `NetworkObject`s to other `NetworkObject`s at runtime while networking.
+
+The approach we are presenting here is limited by current MLAPI architecture and its internal structure. We will touch on these limitations and reasons below.
+
+# Motivation
+[motivation]: #motivation
+
+We want to offer `NetworkObject` reparenting solution within MLAPI to help developers synchronizing `transform` parent-child relationships of `NetworkObject`s.
+
+It is often not easy to grok the parenting in networking, also your choice of networking framework would have its limitations you don't necessarily know up until trying to implement and cover the edge cases. Here, we want to provide a solution that plays nicely with current MLAPI limitations and we expect this "NetworkObject Parenting" concept to evolve and change over time when MLAPI matures.
+
+With this RFC implemented, we expect developers to reparent their `NetworkObject`s at runtime during networked gameplay and synchronize across the network (server to clients) out-of-the-box within certain limits and conditions.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+## Rules
+
+Let's list a few basic `NetworkObject` reparenting rules below.
+
+### Only A Server (or A Host) Can Reparent
+
+Similar to Ownership, only the server (or host, which is both a server and a client at the same time) can control reparenting of a `NetworkObject` in the network.
+
+Clients however, can send RPCs to server and execute a logic server-side that ultimately makes server to reparent a `NetworkObject`.
+
+### Only Reparenting Under A NetworkObject (Or To The Root) Is Valid
+
+A `NetworkObject` can only be reparented under another `NetworkObject` (`GameObject` with `NetworkObject` component attached). Only exception is moving a `NetworkObject` to the root of the scene hierarchy.
+
+This is simply due to the fact that MLAPI would not be able to identify & locate new parent on the remote-side if it was a non-`NetworkObject` parent. Again, except moving it to the root because we could identify no parent (root) scenario without `NetworkObject` identification or scene hierarchy traversal.
+
+### Only Reparenting During Networking Is Valid
+
+A `NetworkObject` can only be reparented while networking, in other terms you can only reparent while listening/running as a server.
+
+If we were to allow moves while not networking, we would be desynced immediately when we switch to networking. Also reparenting a `NetworkObject` under a non-`NetworkObject` while not networking would sound valid but that would not be replicable on the remote-side since MLAPI does not cover full scene hierarchy synchronization (and this might be a good thing, hence server vs client scene hierarchies).
+
+In short, we have to keep initial `NetworkObject` formation in the scene hierarchy identical between instances so that we could rely on initial states to be in sync as reference points.
+
+### Invalid Reparenting Will Move NetworkObject Back To Its Original Location
+
+If an invalid/unsupported `NetworkObject` parenting happens, MLAPI will immediately pop it back to its previous location to keep things in sync and also will print relevant error/warning messages to indicate the issue.
+
+## Moves
+
+We will assume our initial scene hierarchy is looking like this:
+
+```
+Sun
+Tree
+Camera
+Player (NetworkObject)
+  |_ Head
+  |_ Body
+  |_ Arms
+  | |_ LeftArm
+  | | |_ LeftHand (NetworkObject)
+  | |_ RightArm
+  |   |_ RightHand (NetworkObject)
+  |_ Legs
+Axe (NetworkObject)
+```
+
+So, let's try a few moves!
+
+### Root/Axe → RightHand/Axe
+
+In networked gameplay, this is a valid move because `Axe (NetworkObject)` is being moved under `RightHand (NetworkObject)`. We know about their `NetworkObjectId`s and it will be replicated across the network to clients.
+
+Now, our hierarchy would look like this:
+
+```
+Sun
+Tree
+Camera
+Player (NetworkObject)
+  |_ Head
+  |_ Body
+  |_ Arms
+  | |_ LeftArm
+  | | |_ LeftHand (NetworkObject)
+  | |_ RightArm
+  |   |_ RightHand (NetworkObject)
+  |     |_ Axe (NetworkObject)
+  |_ Legs
+```
+
+### RightHand/Axe → Body/Axe
+
+todo
+
+Explain the proposal as if it was already included in the Unity Multiplayer and you were teaching it to another Unity developer. That generally means:
+
+- Introducing new named concepts.
+- Explaining the feature largely in terms of examples.
+- Explaining how Unity developers should _think_ about the feature, and how it should impact the way they develop multiplayer projects in Unity. It should explain the impact as concretely as possible.
+- If applicable, provide sample error messages, deprecation warnings, or migration guidance.
+- If applicable, describe the differences between teaching this to existing Unity developers and new Unity developers.
+
+For implementation-oriented RFCs (e.g. for framework internals), this section should focus on how Unity Multiplayer contributors should think about the change, and give examples of its concrete impact. For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+This is the technical portion of the RFC. Explain the design in sufficient detail that:
+
+- Its interaction with other features is clear.
+- It is reasonably clear how the feature would be implemented.
+- Corner cases are dissected by example.
+
+The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Why should we _not_ do this?
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered and what is the rationale for not choosing them?
+- What is the impact of not doing this?
+
+# Prior art
+[prior-art]: #prior-art
+
+Discuss prior art, both the good and the bad, in relation to this proposal. A few examples of what this can include are:
+
+- For framework, tools, and library proposals: Does this feature exist in other networking stacks and what experience have their community had?
+- For community proposals: Is this done by some other community and what were their experiences with it?
+- For other teams: What lessons can we learn from what other communities have done here?
+- Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.
+
+This section is intended to encourage you as an author to think about the lessons from other projects, provide readers of your RFC with a fuller picture. If there is no prior art, that is fine - your ideas are interesting to us whether they are brand new or if it is an adaptation from other projects.
+
+Note that while precedent set by other projects is some motivation, it does not on its own motivate an RFC. Please also take into consideration that Unity Multiplayer sometimes intentionally diverges from common multiplayer networking features.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+- What parts of the design do you expect to resolve through the RFC process before this gets merged?
+- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
+- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+Think about what the natural extension and evolution of your proposal would be and how it would affect the Unity Multiplayer as a whole in a holistic way. Try to use this section as a tool to more fully consider all possible interactions with the Unity Multiplayer in your proposal. Also consider how the this all fits into the roadmap for the project and the team.
+
+This is also a good place to "dump ideas", if they are out of scope for the RFC you are writing but otherwise related.
+
+If you have tried and cannot think of any future possibilities, you may simply state that you cannot think of anything.
+
+Note that having something written down in the future-possibilities section is not a reason to accept the current or a future RFC; such notes should be in the section on motivation or rationale in this or subsequent RFCs. The section merely provides additional information.

--- a/text/0000-object-parenting.md
+++ b/text/0000-object-parenting.md
@@ -59,14 +59,14 @@ Sun
 Tree
 Camera
 Player (NetworkObject)
-  |_ Head
-  |_ Body
-  |_ Arms
-  | |_ LeftArm
-  | | |_ LeftHand (NetworkObject)
-  | |_ RightArm
-  |   |_ RightHand (NetworkObject)
-  |_ Legs
+  ├─ Head
+  ├─ Body
+  ├─ Arms
+  │  ├─ LeftArm
+  │  │  └─ LeftHand (NetworkObject)
+  │  └─ RightArm
+  │     └─ RightHand (NetworkObject)
+  └─ Legs
 Axe (NetworkObject)
 ```
 
@@ -124,7 +124,7 @@ We'd get an error message in the logs similar to this:
 Invalid parenting, NetworkObject moved under a non-NetworkObject parent
 ```
 
-### RightHand/Axe → Scene Root
+### RightHand/Axe → SceneRoot/Axe
 
 todo
 

--- a/text/0000-object-parenting.md
+++ b/text/0000-object-parenting.md
@@ -74,7 +74,7 @@ So, let's try a few moves!
 
 ### Root/Axe → RightHand/Axe
 
-This is a **valid** move because `Axe (NetworkObject)` is being moved under `RightHand (NetworkObject)`. We know about their `NetworkObjectId`s and it will be replicated across the network to clients by the server.
+This is a **valid** move because `Axe (NetworkObject)` is being moved under `RightHand (NetworkObject)`. We know about their `NetworkObjectId`s and it will be replicated across the network to the clients by the server.
 
 Now, our hierarchy is looking like this:
 
@@ -97,7 +97,7 @@ Player (NetworkObject)
 
 ### RightHand/Axe → Body/Axe
 
-This is an **invalid** move because `Axe (NetworkObject)` is being moved under `Body` which is _not_ a `NetworkObject`. It does _not_ have a `NetworkObjectId` and it can _not_ be replicated and synced on clients.
+This is an **invalid** move because `Axe (NetworkObject)` is being moved under `Body` which is _not_ a `NetworkObject`. It does _not_ have a `NetworkObjectId` and it can _not_ be replicated and synced on the clients.
 
 So, we tried to do this but it did _not_ succeed:
 
@@ -126,7 +126,24 @@ Invalid parenting, NetworkObject moved under a non-NetworkObject parent
 
 ### RightHand/Axe → SceneRoot/Axe
 
-todo
+This is a **valid** move because `Axe (NetworkObject)` is being moved to the scene root (no parent). Even though there is no `NetworkObjectId` to sync, empty/null parent _can_ be synced across the network on the clients.
+
+```
+Sun
+Tree
+Camera
+Player (NetworkObject)
+  ├─ Head
+  ├─ Body
+  ├─ Arms
+  │  ├─ LeftArm
+  │  │  └─ LeftHand (NetworkObject)
+  │  └─ RightArm
+  │     └─ RightHand (NetworkObject)
+  │               [from] ───┐
+  └─ Legs                   ├ OK
+Axe (NetworkObject) [to] <──┘
+```
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation

--- a/text/0000-object-parenting.md
+++ b/text/0000-object-parenting.md
@@ -52,7 +52,7 @@ If an invalid/unsupported `NetworkObject` parenting happens, MLAPI will immediat
 
 ## Moves
 
-We will assume our initial scene hierarchy is looking like this:
+We will assume that our initial scene hierarchy is looking like this:
 
 ```
 Sun
@@ -74,24 +74,25 @@ So, let's try a few moves!
 
 ### Root/Axe → RightHand/Axe
 
-In networked gameplay, this is a valid move because `Axe (NetworkObject)` is being moved under `RightHand (NetworkObject)`. We know about their `NetworkObjectId`s and it will be replicated across the network to clients.
+In networked gameplay, this is a valid move because `Axe (NetworkObject)` is being moved under `RightHand (NetworkObject)`. We know about their `NetworkObjectId`s and it will be replicated across the network to clients by the server.
 
-Now, our hierarchy would look like this:
+Now, our hierarchy is looking like this:
 
 ```
 Sun
 Tree
 Camera
 Player (NetworkObject)
-  |_ Head
-  |_ Body
-  |_ Arms
-  | |_ LeftArm
-  | | |_ LeftHand (NetworkObject)
-  | |_ RightArm
-  |   |_ RightHand (NetworkObject)
-  |     |_ Axe (NetworkObject)
-  |_ Legs
+  ├─ Head
+  ├─ Body
+  ├─ Arms
+  │  ├─ LeftArm
+  │  │  └─ LeftHand (NetworkObject)
+  │  └─ RightArm
+  │     └─ RightHand (NetworkObject)
+  │        └─ Axe (NetworkObject) [to] <──┐
+  └─ Legs                                 │ OK
+                                [from] ───┘
 ```
 
 ### RightHand/Axe → Body/Axe


### PR DESCRIPTION
[See the linked RFC document →](https://github.com/Unity-Technologies/com.unity.multiplayer.rfcs/blob/rfc/object-parenting/text/0000-networkobject-parenting.md)

This RFC proposal is an attempt to outline basic needs for a `NetworkObject` (re)parenting managed by the server at both scene authoring time and at runtime.
There are a couple of limitations, however, we still want to deliver this functionality within MLAPI which would work out-of-the-box for some use-cases and some non-expert network programmers.